### PR TITLE
Remove "no handler" message

### DIFF
--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -126,7 +126,6 @@ handler="$(grep -v "^#" "$handlers_file" | grep "^$command|" | head -1)"
 
 if [ -z "$handler" ]; then
   # no return, so this is not a command we recognise
-  send_message "$chat_id" "$(url_encode "I have no handler for command /$command - why don't you let me handle it? :)")" >/dev/null
   exit
 fi
 


### PR DESCRIPTION
It assumes that every command belongs to it, including `/tslist`, `/list` and others that are handled by the other bots, complaining about commands it doesn't know about.

This change would remove that message, effectively making the bot not answer to commands it doesn't know.
